### PR TITLE
NUnit support: Copy and modified tests to use NUnit for use under Mono

### DIFF
--- a/NPEG.Mono.sln
+++ b/NPEG.Mono.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPEG", "NPEG\NPEG.csproj", "{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NPEG.Tests.NUnit", "NPEG.Tests.NUnit\NPEG.Tests.NUnit.csproj", "{913C7583-5FFA-4170-8F59-FD745F4D97CE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		DIAGNOSTICS|Any CPU = DIAGNOSTICS|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}.DIAGNOSTICS|Any CPU.ActiveCfg = DIAGNOSTICS|Any CPU
+		{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}.DIAGNOSTICS|Any CPU.Build.0 = DIAGNOSTICS|Any CPU
+		{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}.Release|Any CPU.Build.0 = Release|Any CPU
+		{913C7583-5FFA-4170-8F59-FD745F4D97CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{913C7583-5FFA-4170-8F59-FD745F4D97CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{913C7583-5FFA-4170-8F59-FD745F4D97CE}.DIAGNOSTICS|Any CPU.ActiveCfg = DIAGNOSTICS|Any CPU
+		{913C7583-5FFA-4170-8F59-FD745F4D97CE}.DIAGNOSTICS|Any CPU.Build.0 = DIAGNOSTICS|Any CPU
+		{913C7583-5FFA-4170-8F59-FD745F4D97CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{913C7583-5FFA-4170-8F59-FD745F4D97CE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = NPEG\NPEG.csproj
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/NPEG.Tests.NUnit/BugRegression.cs
+++ b/NPEG.Tests.NUnit/BugRegression.cs
@@ -1,0 +1,50 @@
+﻿using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using NPEG.GrammarInterpreter;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class BugRegression
+	{
+
+		[Test]
+		public void Recursive_Grammar_Used_In_Predicate_Should_Not_Append_To_Ast()
+		{
+			var rules = PEGrammar.Load(@"
+NewLine: [\r][\n] / [\n][\r] / [\n] / [\r];
+Space: ' ';
+Tab: [\t];
+s: ( Space / Tab  )+;
+S: ( NewLine )+;
+W: (s / S);
+(?<Notes>): 'Notes'\i s* ':' (!Scenario .)+;
+(?<Scenario>): 'Scenario'\i s* ':'  (?<Title> (!S .)+ ) W+ Notes?;
+(?<Document>): W* (Scenario W*)+ !. ;
+			");
+
+			var bytes = Encoding.UTF8.GetBytes(
+@"
+Scenario:	User creates a new template with a name  
+	 
+Notes: (markdown)
+
+ 
+Scenario:	User creates a new template with case information 
+
+Notes: (markdown)
+");
+			var visitor = new NpegParserVisitor(new ByteInputIterator(bytes));
+			rules.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			var ast = visitor.AST;
+			var scenarios = ast.Children.Where(x => x.Token.Name.Equals("Scenario")).ToList();
+			Assert.IsTrue(scenarios.Count == 2);
+			var notes = scenarios[0].Children["Notes"];
+			Assert.IsTrue(!notes.Children.Any(), "notes should not have any children");
+			// previously Notes would contain nested Scenario due to predicate !Scenario
+		}
+
+	}
+}

--- a/NPEG.Tests.NUnit/ByteInputIteratorTests.cs
+++ b/NPEG.Tests.NUnit/ByteInputIteratorTests.cs
@@ -1,0 +1,109 @@
+﻿#region License
+
+/* **********************************************************************************
+ * Copyright (c) Leblanc Meneses
+ * This source code is subject to terms and conditions of the MIT License
+ * for NPEG. A copy of the license can be found in the License.txt file
+ * at the root of this distribution. 
+ * By using this source code in any fashion, you are agreeing to be bound by the terms of the 
+ * MIT License.
+ * You must not remove this notice from this software.
+ * **********************************************************************************/
+
+#endregion
+
+using System;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using NPEG.ApplicationExceptions;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class ByteInputIteratorTests
+	{
+		
+
+
+		[Test]
+		public void Iterator_Initialization()
+		{
+			var input = "01234567890123456789";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+
+			// tests that iterator begins at zero based index
+			Assert.IsTrue(iterator.Index == 0);
+			Assert.IsTrue(iterator.Length == 20);
+			Assert.IsTrue(iterator.Current() == '0');
+			Assert.IsTrue(iterator.Next() == '1');
+			Assert.IsTrue(iterator.Previous() == '0');
+			Assert.IsTrue(bytes.SequenceEqual(iterator.Text(0, 19)), "Text unable to return complete input.");
+		}
+
+		[Test]
+		public void Iterator_GetText_Limit()
+		{
+			var bytes = Encoding.UTF8.GetBytes("01234567890123456789");
+			var iterator = new ByteInputIterator(bytes);
+			Assert.IsTrue(Encoding.ASCII.GetBytes("0").SequenceEqual(iterator.Text(0, 0)), "Text unable to return first character.");
+			Assert.IsTrue(Encoding.ASCII.GetBytes("9").SequenceEqual(iterator.Text(19, 19)), "Text unable to return last character.");
+			Assert.IsTrue(Encoding.ASCII.GetBytes("01").SequenceEqual(iterator.Text(0, 1)),
+			              "Text unable to return specified start and end characters inclusive.");
+
+			try
+			{
+				iterator.Text(19, 0);
+				Assert.Fail("Start must be <= End");
+			}
+			catch (IteratorUsageException e)
+			{
+			}
+		}
+
+		[Test]
+		public void Iterator_OutofRange()
+		{
+			var bytes = Encoding.UTF8.GetBytes("");
+			var iterator = new ByteInputIterator(bytes);
+			Assert.IsTrue(iterator.Index == 0);
+			Assert.IsTrue(iterator.Length == 0);
+			Assert.IsTrue(iterator.Current() == -1);
+			Assert.IsTrue(iterator.Index == 0);
+			Assert.IsTrue(iterator.Next() == -1);
+			Assert.IsTrue(iterator.Index == 0);
+			Assert.IsTrue(iterator.Previous() == -1);
+			Assert.IsTrue(iterator.Index == 0);
+		}
+
+		[Test]
+		public void Iterator_Index()
+		{
+			var bytes = Encoding.UTF8.GetBytes("01234567890123456789");
+			var iterator = new ByteInputIterator(bytes);
+			Assert.IsTrue(iterator.Index == 0);
+			Assert.IsTrue(iterator.Length == bytes.Length);
+
+			for (int i = 0; i < bytes.Length; i++)
+			{
+				Assert.IsTrue(iterator.Index == i);
+				Assert.IsTrue(iterator.Current() == bytes[i]);
+				if (i < bytes.Length - 1)
+				{
+					Assert.IsTrue(iterator.Next() == bytes[i + 1]);
+				}
+			}
+
+			for (int i = bytes.Length - 1; i >= 0; i--)
+			{
+				Assert.IsTrue(iterator.Index == i);
+				Assert.IsTrue(iterator.Current() == bytes[i]);
+				if (i > 0)
+				{
+					Assert.IsTrue(iterator.Previous() == bytes[i - 1]);
+				}
+			}
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/CompositeVisitorTests.cs
+++ b/NPEG.Tests.NUnit/CompositeVisitorTests.cs
@@ -1,0 +1,434 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using NPEG.Extensions;
+using NPEG.NonTerminals;
+using NPEG.Terminals;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class CompositeVisitorTests
+	{
+		
+
+
+		[Test]
+		public void CompositeVisitor_RecursiveParentheses()
+		{
+			#region Composite
+
+			AExpression DIGITS = new CapturingGroup("DIGITS", new OneOrMore(new CharacterClass {ClassExpression = "[0-9]"}));
+			AExpression ENCLOSEDDIGITS = new RecursionCreate("ParethesisFunction",
+			                                                 new PrioritizedChoice(
+			                                                 	DIGITS
+			                                                 	,
+			                                                 	new CapturingGroup("ENCLOSEDDIGITS",
+			                                                 	                   new Sequence(
+			                                                 	                   	new Literal {MatchText = "("},
+			                                                 	                   	new RecursionCall("ParethesisFunction")
+			                                                 	                   	).Sequence(new Literal {MatchText = ")"})
+			                                                 		)
+			                                                 	)
+				);
+
+			AExpression ROOT = new CapturingGroup("RECURSIONTEST", ENCLOSEDDIGITS);
+
+			#endregion
+
+			var input = Encoding.UTF8.GetBytes("((((((123))))))");
+			var visitor = new NpegParserVisitor(new ByteInputIterator(input));
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "RECURSIONTEST");
+			Assert.IsTrue(node.Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Token.Name == "ENCLOSEDDIGITS");
+			Assert.IsTrue(node.Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "ENCLOSEDDIGITS");
+			Assert.IsTrue(node.Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "ENCLOSEDDIGITS");
+			Assert.IsTrue(node.Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Token.Name == "ENCLOSEDDIGITS");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Token.Name == "ENCLOSEDDIGITS");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Token.Name == "ENCLOSEDDIGITS");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Token.Name == "DIGITS");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Children.Count == 0);
+		}
+
+
+		[Test]
+		public void CompositeVisitor_NestedRecursive()
+		{
+			#region Composite
+
+			var DIGITS = new CapturingGroup("DIGITS", new OneOrMore(new CharacterClass {ClassExpression = "[0-9]"}));
+			var LTENCLOSED = new RecursionCreate("RECURSIONLTENCLOSED",
+			                                     new PrioritizedChoice(DIGITS,
+			                                                           new CapturingGroup("LTENCLOSED",
+			                                                                              new Sequence(
+			                                                                              	new Literal {MatchText = "<"},
+			                                                                              	new RecursionCall(
+			                                                                              		"RECURSIONLTENCLOSED")
+			                                                                              	).Sequence(new Literal
+			                                                                              	           	{MatchText = ">"})
+			                                                           	)
+			                                     	)
+				);
+			var PENCLOSED = new RecursionCreate("RECURSIONPENCLOSED",
+			                                    new PrioritizedChoice(LTENCLOSED,
+			                                                          new CapturingGroup("PENCLOSED",
+			                                                                             new Sequence(
+			                                                                             	new Literal {MatchText = "("},
+			                                                                             	new RecursionCall("RECURSIONPENCLOSED")
+			                                                                             	).Sequence(new Literal
+			                                                                             	           	{MatchText = ")"})
+			                                                          	)
+			                                    	)
+				);
+
+			AExpression ROOT = new CapturingGroup("NESTEDRECURSIONTEST", PENCLOSED);
+
+			#endregion
+
+			var input = "(((<<<123>>>)))";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+			Assert.IsTrue(node.Token.Name == "NESTEDRECURSIONTEST");
+			Assert.IsTrue(node.Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Token.Name == "PENCLOSED");
+			Assert.IsTrue(node.Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "PENCLOSED");
+			Assert.IsTrue(node.Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "PENCLOSED");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Token.Name == "LTENCLOSED");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Token.Name == "LTENCLOSED");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Token.Name == "LTENCLOSED");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Children[0].Children[0].Children[0].Children.Count == 1);
+		}
+
+
+		[Test]
+		public void CompositeVisitor_CapturingGroup_SandBoxTest_PriorityChoice1()
+		{
+			PrioritizedChoice newline = new PrioritizedChoice(
+				new Literal {MatchText = "\r\n"}, // windows
+				new Literal {MatchText = "\r\r"} // old macs
+				)
+				.Or(new Literal {MatchText = "\n"}); // linux
+
+			// Single Line Comment
+			var singleLineComment = new Sequence(
+				new Literal {MatchText = "//"},
+				new Sequence(
+					new NotPredicate(newline),
+					new AnyCharacter()
+					)
+					.Star()
+				);
+
+			// Multiline Comment
+			var multiLineComment = new Sequence(
+				new Literal {MatchText = "/*"},
+				new Sequence(
+					new NotPredicate(new Literal {MatchText = "*/"}),
+					new AnyCharacter()
+					)
+					.Star()
+					.Sequence(new Literal {MatchText = "*/"})
+				);
+
+			var comment = new PrioritizedChoice(singleLineComment, multiLineComment);
+
+			var whitespace = new PrioritizedChoice(
+				new CharacterClass {ClassExpression = "[ \t\r\n\v]"},
+				comment
+				);
+
+			var label = new CapturingGroup("Label",
+			                               new Sequence(
+			                               	new CharacterClass {ClassExpression = "[a-zA-Z_]"},
+			                               	// must start with alpha character
+			                               	new ZeroOrMore(new CharacterClass {ClassExpression = "[a-zA-Z0-9_]"})
+			                               	)
+				);
+
+			var backreference = new CapturingGroup("DynamicBackReferencing",
+			                                       new Sequence(
+			                                       	new Literal {MatchText = @"\k<"},
+			                                       	new Sequence(new ZeroOrMore(whitespace), label).Sequence(
+			                                       		new ZeroOrMore(whitespace))
+			                                       	)
+			                                       	.Sequence(
+			                                       		new Optional(
+			                                       			new Sequence(
+			                                       				new Sequence(
+			                                       					new Literal {MatchText = "["},
+			                                       					new CapturingGroup("CaseSensitive",
+			                                       					                   new Literal {MatchText = @"\i"}
+			                                       						)
+			                                       					),
+			                                       				new Literal {MatchText = "]"}
+			                                       				)
+			                                       			)
+			                                       	)
+			                                       	.Sequence(
+			                                       		new Sequence(new ZeroOrMore(whitespace), new Literal {MatchText = ">"})
+			                                       	)
+				);
+
+			var root = new CapturingGroup("Test",
+			                              new Sequence(
+			                              	backreference,
+			                              	new NotPredicate(new AnyCharacter())
+			                              	)
+				);
+
+			var input = @"\k< CapturedLabelVariableName >";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "DynamicBackReferencing");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+		}
+
+
+		[Test]
+		public void CompositeVisitor_CapturingGroup_SandBoxTest_PriorityChoice2()
+		{
+			var mSpace = new CharacterClass {ClassExpression = "[ \t]"};
+			var limiting = new CapturingGroup("LimitingRepetition",
+			                                  new Sequence(
+			                                  	new Sequence(
+			                                  		new Literal {MatchText = "{"},
+			                                  		new ZeroOrMore(mSpace)
+			                                  		),
+			                                  	new PrioritizedChoice(
+			                                  		new CapturingGroup("BETWEEN",
+			                                  		                   new Sequence(
+			                                  		                   	new CapturingGroup("Min",
+			                                  		                   	                   new OneOrMore(new CharacterClass
+			                                  		                   	                                 	{ClassExpression = "[0-9]"}))
+			                                  		                   		.Sequence(new ZeroOrMore(mSpace)),
+			                                  		                   	new Literal {MatchText = ","}
+			                                  		                   	)
+			                                  		                   	.Sequence(
+			                                  		                   		new Sequence(new ZeroOrMore(mSpace),
+			                                  		                   		             new CapturingGroup("Max",
+			                                  		                   		                                new OneOrMore(
+			                                  		                   		                                	new CharacterClass
+			                                  		                   		                                		{
+			                                  		                   		                                			ClassExpression = "[0-9]"
+			                                  		                   		                                		})))
+			                                  		                   	)
+			                                  			)
+			                                  		,
+			                                  		new CapturingGroup("ATMOST",
+			                                  		                   new Sequence(
+			                                  		                   	new Literal {MatchText = ","}
+			                                  		                   	,
+			                                  		                   	new Sequence(new ZeroOrMore(mSpace),
+			                                  		                   	             new CapturingGroup("Max",
+			                                  		                   	                                new OneOrMore(
+			                                  		                   	                                	new CharacterClass
+			                                  		                   	                                		{ClassExpression = "[0-9]"})))
+			                                  		                   	)
+			                                  			)
+			                                  		)
+			                                  		.Or
+			                                  		(
+			                                  			new CapturingGroup("ATLEAST",
+			                                  			                   new Sequence(
+			                                  			                   	new Sequence(new ZeroOrMore(mSpace),
+			                                  			                   	             new CapturingGroup("Min",
+			                                  			                   	                                new OneOrMore(
+			                                  			                   	                                	new CharacterClass
+			                                  			                   	                                		{
+			                                  			                   	                                			ClassExpression = "[0-9]"
+			                                  			                   	                                		}))).Sequence(
+			                                  			                   	                                			new ZeroOrMore(mSpace))
+			                                  			                   	,
+			                                  			                   	new Literal {MatchText = ","}
+			                                  			                   	)
+			                                  				)
+			                                  		)
+			                                  		.Or
+			                                  		(
+			                                  			new CapturingGroup("EXACT",
+			                                  			                   new OneOrMore(new CharacterClass {ClassExpression = "[0-9]"}))
+			                                  		)
+			                                  	)
+			                                  	.Sequence(
+			                                  		new ZeroOrMore(mSpace)
+			                                  	)
+			                                  	.Sequence(
+			                                  		new Literal {MatchText = "}"}
+			                                  	)
+				);
+
+			var any = new CapturingGroup("AnyCharacter", new Literal {MatchText = "."});
+
+			var expression = new CapturingGroup("Expression",
+			                                    new PrioritizedChoice(
+			                                    	new Sequence(any, limiting),
+			                                    	new Sequence(limiting, any)
+			                                    	)
+				);
+
+			var input = ".{77,55}";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var visitor = new NpegParserVisitor(
+				new ByteInputIterator(bytes)
+			);
+			expression.Accept(visitor);
+
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Expression");
+			Assert.IsTrue(node.Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[1].Token.Name == "LimitingRepetition");
+		}
+
+
+		[Test]
+		public void CompositeVisitor_CapturingGroup_SandBoxTest_PriorityChoice3()
+		{
+			var prefix = new PrioritizedChoice(
+				new CapturingGroup("AndPredicate", new Literal {MatchText = "&"}),
+				new CapturingGroup("NotPredicate", new Literal {MatchText = "!"})
+				);
+
+			PrioritizedChoice suffix = new PrioritizedChoice(
+				new CapturingGroup("ZeroOrMore", new Literal {MatchText = "*"}),
+				new CapturingGroup("OneOrMore", new Literal {MatchText = "+"})
+				)
+				.Or(new CapturingGroup("Optional", new Literal {MatchText = "?"}));
+
+			var terminal = new CapturingGroup("AnyCharacter", new Literal {MatchText = "."});
+			var expression = new CapturingGroup("Expression",
+			                                    new PrioritizedChoice(
+			                                    	// match prefixes first
+			                                    	prefix.Plus()
+			                                    		.Sequence(terminal)
+			                                    	,
+			                                    	// match suffixes next
+			                                    	terminal
+			                                    		.Sequence(
+			                                    			suffix.Plus()
+			                                    		)
+			                                    	)
+			                                    	.Or(terminal)
+			                                    	.Plus()
+				);
+
+			var input = ".";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			expression.Accept(visitor);
+
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children.Count == 1);
+			Assert.IsTrue(node.Token.Name == "Expression");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Token.Name == "AnyCharacter");
+		}
+
+
+		[Test]
+		public void CompositeVisitor_Recursiveness()
+		{
+			var whitespace = new CharacterClass {ClassExpression = "[ \t\r\n\v]"};
+
+			var terminal = new PrioritizedChoice(
+				new CapturingGroup("AnyCharacter", new Literal {MatchText = "."})
+				,
+				new CapturingGroup("CapturingGroup",
+				                   new Sequence(
+				                   	new Literal {MatchText = "(?<"},
+				                   	new CapturingGroup("ReplacementNode",
+				                   	                   new OneOrMore(
+				                   	                   	new CharacterClass {ClassExpression = "[a-z0-9A-Z]"}
+				                   	                   	)
+				                   		)
+				                   	)
+				                   	.Sequence(new Literal {MatchText = ">"})
+				                   	.Sequence(new RecursionCall("Expression"))
+				                   	.Sequence(new Literal {MatchText = ")"})
+					)
+				);
+
+			var sequence = new CapturingGroup(
+				"Sequence",
+				new Sequence(
+					terminal,
+					new ZeroOrMore(whitespace)
+					).Plus()
+				) {DoReplaceBySingleChildNode = true};
+
+			var prioritizedchoice = new CapturingGroup("PrioritizedChoice",
+			                                           new Sequence(
+			                                           	sequence,
+			                                           	new Literal {MatchText = "/"}
+			                                           	)
+			                                           	.Sequence(new ZeroOrMore(whitespace))
+			                                           	.Sequence(sequence)
+			                                           	.Sequence(
+			                                           		new ZeroOrMore(
+			                                           			new Sequence(
+			                                           				new ZeroOrMore(whitespace),
+			                                           				new Literal {MatchText = "/"}
+			                                           				)
+			                                           				.Sequence(new ZeroOrMore(whitespace))
+			                                           				.Sequence(sequence)
+			                                           				.Plus()
+			                                           			)
+			                                           	)
+				);
+
+			var expression = new CapturingGroup("Root",
+			                                    new RecursionCreate("Expression",
+			                                                        new PrioritizedChoice(prioritizedchoice, sequence)));
+
+
+			var input = @"(?<NPEGNode>./.. )";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			expression.Accept(visitor);
+
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Root");
+			Assert.IsTrue(node.Children.Count == 1);
+			Assert.IsTrue(node.Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Token.Name == "CapturingGroup");
+			Assert.IsTrue(node.Children[0].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "ReplacementNode");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "PrioritizedChoice");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Children[1].Token.Name == "AnyCharacter");
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/GrammarInterpreterTests.cs
+++ b/NPEG.Tests.NUnit/GrammarInterpreterTests.cs
@@ -1,0 +1,483 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using NPEG.ApplicationExceptions;
+using NPEG.Extensions;
+using NPEG.GrammarInterpreter;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class GrammarInterpreterTests
+	{
+		
+
+		[Test]
+		public void PEGrammar_Literal()
+		{
+			AExpression caseSensitive = PEGrammar.Load(@"(?<Expression>): 'Hello World';");
+
+			var input = "hello world";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			caseSensitive.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+
+			AExpression notCaseSensitive = PEGrammar.Load(@"(?<Expression>): 'Hello World'\i;");
+			input = "hello world";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			notCaseSensitive.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Expression");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+
+
+			// not sure if it would be better to use verbatim identifier @"" for escaping
+			// escape back slash inside double quotes
+			input = @"\";
+			AExpression escape = PEGrammar.Load(@"(?<Literal>): ""\\"";");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			escape.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			Assert.IsTrue(@"\" == visitor.AST.Token.ValueAsString(iterator));
+
+			input = @"\";
+			escape = PEGrammar.Load(@"(?<Literal>): '\\';");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			escape.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			Assert.IsTrue(@"\" == visitor.AST.Token.ValueAsString(iterator));
+		}
+
+
+		[Test]
+		[Timeout(2000)]
+		//[ExpectedException(typeof (InfiniteLoopDetectedException))]
+		public void PEGrammar_ZeroOrMore_InfiniteLoopTest()
+		{
+			AExpression caseSensitive = PEGrammar.Load(@"(?<Expression>): (.*)*;");
+
+			var input = "";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var visitor = new NpegParserVisitor(new ByteInputIterator(bytes));
+			caseSensitive.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+		[Test]
+		[Timeout(2000)]
+		//[ExpectedException(typeof (InfiniteLoopDetectedException))]
+		public void PEGrammar_LimitingRepetition_InfiniteLoopTest()
+		{
+			string input = "";
+			AExpression caseSensitive = PEGrammar.Load(@"(?<Expression>): (.*){0,};");
+
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var visitor = new NpegParserVisitor(new ByteInputIterator(bytes));
+			caseSensitive.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+		[Test]
+		[Timeout(2000)]
+		//[ExpectedException(typeof (InfiniteLoopDetectedException))]
+		public void PEGrammar_OneOrMore_InfiniteLoopTest()
+		{
+			string input = "";
+			AExpression caseSensitive = PEGrammar.Load(@"(?<Expression>): (.*)+;");
+
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var visitor = new NpegParserVisitor(new ByteInputIterator(bytes));
+			caseSensitive.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+		[Test]
+		[Timeout(2000)]
+		public void PEGrammar_OneOrMore_WithPredicate_DoesNotCauseInfiniteLoop()
+		{
+			string input = "";
+			AExpression caseSensitive = PEGrammar.Load(@"(?<Expression>): (.*)+;");
+
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var visitor = new NpegParserVisitor(new ByteInputIterator(bytes));
+			caseSensitive.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		// Root node must always be a capturing group.
+		[Test]
+		public void PEGrammar_LimitingRepetition()
+		{
+			var grammar =
+				@"
+                                (?<ThreeDigitCode>): [0-9]{3,3};
+                                (?<PhoneNumber>): ThreeDigitCode '-' ThreeDigitCode '-' (?<FourDigitCode>[0-9]{4});
+                              ";
+
+			var ROOT = PEGrammar.Load(grammar);
+
+			var input = "123-456-7890";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+
+			Assert.IsTrue(node.Token.Name == "PhoneNumber");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+			Assert.IsTrue(node.Children[0].Token.Name == "ThreeDigitCode");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "123");
+			Assert.IsTrue(node.Children[1].Token.Name == "ThreeDigitCode");
+			Assert.IsTrue(node.Children[1].Token.ValueAsString(iterator) == "456");
+			Assert.IsTrue(node.Children[2].Token.Name == "FourDigitCode");
+			Assert.IsTrue(node.Children[2].Token.ValueAsString(iterator) == "7890");
+		}
+
+		[Test]
+		public void PEGrammar_DynamicBackReference_Xml()
+		{
+			var grammar =
+			@"
+					(?<Tag>): [a-zA-Z0-9]+;
+					(?<StartTag>): '<' Tag '>';
+					(?<EndTag>): '</' \k<Tag> '>' ;
+					(?<Body>): (Xml / (!EndTag .))+;
+					(?<Xml>): (StartTag Body EndTag )+;
+			";
+
+			var input = @"
+					<test>
+						test data start
+						<test1>
+							test1 data start
+							<test2>
+								text2 data start
+								text2 data end
+							</test2>
+							test1 data end
+						</test1>
+						test data end
+					</test>
+			".Trim();
+
+			var ROOT = PEGrammar.Load(grammar);
+			var iterator = new ByteInputIterator(Encoding.UTF8.GetBytes(input));
+			var visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+
+			throw new NotImplementedException("Refactoring - plan on changing backreferencing logic inside NPEGParser - just placeholder of failing test for now; conserve memory");
+		}
+
+		[Test]
+		public void PEGrammar_LimitingRepetition_VariableExpression()
+		{
+			var grammar =
+				@"
+					(?<ESC_AMP_Y>): . . . (?<C1>.) (?<C2>.) 
+					(
+						((?<X> .) (?<D> .{3})) 
+					){(\k<C2> - \k<C1>)+1};
+
+             ";
+
+			var ROOT = PEGrammar.Load(grammar);
+
+								  //.     .      .    C1    C2    X     D     D      D
+			var bytes = new byte[]{0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00};
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "ESC_AMP_Y");
+			Assert.IsTrue(node.Token.End == bytes.Length - 1); // zero index
+
+								//.     .      .    C1    C2  
+			bytes = new byte[] { 0x00, 0x00, 0x00, 0x01, 0x02, 
+				0x00, 0x00, 0x00, 0x00,  //X     D     D      D
+				0x00, 0x00, 0x00, 0x00,  //X     D     D      D
+				0x00
+			};
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+
+			Assert.IsTrue(node.Token.Name == "ESC_AMP_Y");
+			Assert.IsTrue(node.Token.End == bytes.Length - 2); // zero index - expect additional character to not be consumed
+		}
+
+		[Test]
+		public void PEGrammar_PhoneNumber()
+		{
+			var input = "123-456-7890";
+
+			var PhoneNumber = PEGrammar.Load(
+				@"
+                        (?<ThreeDigitCode>): [0-9] [0-9] [0-9];
+                        (?<FourDigitCode>): [0-9] [0-9] [0-9] [0-9];
+                        (?<PhoneNumber>): ThreeDigitCode '-' ThreeDigitCode '-' FourDigitCode;
+                    "
+					.Trim());
+
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			PhoneNumber.Accept(visitor);
+
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "PhoneNumber");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+			Assert.IsTrue(node.Children[0].Token.Name == "ThreeDigitCode");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "123");
+			Assert.IsTrue(node.Children[1].Token.Name == "ThreeDigitCode");
+			Assert.IsTrue(node.Children[1].Token.ValueAsString(iterator) == "456");
+			Assert.IsTrue(node.Children[2].Token.Name == "FourDigitCode");
+			Assert.IsTrue(node.Children[2].Token.ValueAsString(iterator) == "7890");
+		}
+
+		[Test]
+		public void PEGrammar_RecursiveParentheses()
+		{
+			var input = "((((((123))))))";
+			var bytes = Encoding.UTF8.GetBytes(input);
+
+			AExpression ROOT = PEGrammar.Load(
+				@"
+                        (?<DIGITS>): ([0-9])+;
+                        (?<ENCLOSEDDIGITS>): '(' ParethesisFunction ')';
+                        ParethesisFunction: (DIGITS / ENCLOSEDDIGITS);
+                        (?<RECURSIONTEST>): ParethesisFunction;
+                    "
+					.Trim());
+
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+		}
+
+		[Test]
+		public void PEGrammar_MathematicalFormula_Recursion()
+		{
+			AExpression ROOT = PEGrammar.Load(
+				@"
+                    (?<Value>): [0-9]+ / '(' Expr ')';
+                    (?<Product>): Value ((?<Symbol>'*' / '/') Value)*;
+                    (?<Sum>): Product ((?<Symbol>'+' / '-') Product)*;
+                    (?<Expr>): Sum;
+                "
+				);
+
+			String input = "((((12/3)+5-2*(81/9))+1))";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+#warning does not specify expected tree
+		}
+
+
+		[Test]
+		[ExpectedException(typeof (ParsingFatalTerminalException))]
+		public void PEGrammar_Interpreter_Fatal()
+		{
+			AExpression ROOT = PEGrammar.Load(
+				@"
+                    (?<Value>): Fatal<'error'>;
+                "
+				);
+
+			String input = " ";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammar_Interpreter_Warn()
+		{
+			AExpression ROOT = PEGrammar.Load(
+				@"
+                    (?<Value>): Warn<'warning'>;
+                "
+				);
+
+			String input = " ";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			Assert.IsTrue(visitor.Warnings.Count == 1);
+		}
+
+
+		[Test]
+		public void PEGrammar_Interpreter_CodePoint()
+		{
+			AExpression ROOT = PEGrammar.Load(
+				@"
+                    (?<Value>): #x20;
+                "
+				);
+
+			String input = " ";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammar_BooleanAlgebra()
+		{
+			String grammar =
+				@"
+					S: [\s]+;
+                    (?<Gate>): ('*' / 'AND') / ('~*' / 'NAND') / ('+' / 'OR') / ('~+' / 'NOR') / ('^' / 'XOR') / ('~^' / 'XNOR');
+                    ValidVariable: '""' (?<Variable>[a-zA-Z0-9]+) '""'  / '\'' (?<Variable>[a-zA-Z0-9]+) '\'' / (?<Variable>[a-zA-Z]);
+                    VarProjection1: ValidVariable /  (?<Invertor>'!' ValidVariable);
+                    VarProjection2: VarProjection1 / '(' Expression ')' / (?<Invertor>'!' '(' Expression ')');
+                    Expression: S? VarProjection2 S? (Gate S? VarProjection2 S?)*;
+                    (?<BooleanEquation>): Expression !.;
+                "
+					.Trim();
+
+			AExpression ROOT = PEGrammar.Load(grammar);
+
+			// single variable
+			var input = ("A*!B+!A*B");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+#warning Assert.IsTrue(node.Token.Value == input);
+
+
+			// quoted variable
+			input = ("'aA'*!'bB'+!'aA'*'bB'");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			// expression + gate + variable .star()
+			input = ("A*!B*C+!A*B*C");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			// parethesis
+			input = ("((A)*(!B)+(!A)*(B))");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = ("((A)*!(B)+!(A)*(B))");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = ("((A)*(!(B))+(!(A))*(B))");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(!X*Y*!Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(!X*Y*!Z)+(!X*Y*Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(X*Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(!X*Y*!Z)+(!X*Y*Z)+(X*Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = ("((((!X*Y*Z)+(!X*Y*!Z)+(X*Z))))");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			ROOT.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/NPEG.Tests.NUnit.csproj
+++ b/NPEG.Tests.NUnit/NPEG.Tests.NUnit.csproj
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>9.0.30729</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{91334343-5FFA-4170-8F59-FD745F4D97CE}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NPEG.Tests</RootNamespace>
+    <FileAlignment>512</FileAlignment>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <OldToolsVersion>3.5</OldToolsVersion>
+    <UpgradeBackupLocation />
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <AssemblyName>NPEG.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <AssemblyName>NPEG.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DIAGNOSTICS|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\DIAGNOSTICS\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;DIAGNOSTICS</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <WarningLevel>4</WarningLevel>
+    <Optimize>false</Optimize>
+    <AssemblyName>NPEG.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug.Mono|AnyCPU' ">
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug.Mono</OutputPath>
+    <WarningLevel>4</WarningLevel>
+    <AssemblyName>NPEG.Tests.NUnit</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\GlobalAssemblyInfo.cs">
+      <Link>Properties\GlobalAssemblyInfo.cs</Link>
+    </Compile>
+    <Compile Include="CompositeVisitorTests.cs" />
+    <Compile Include="BugRegression.cs" />
+    <Compile Include="StreamInputIteratorTests.cs" />
+    <Compile Include="PEGrammarParserTests.cs" />
+    <Compile Include="GrammarInterpreterTests.cs" />
+    <Compile Include="ByteInputIteratorTests.cs" />
+    <Compile Include="PracticalExampleTests.cs" />
+    <Compile Include="PredicateTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TerminalNodes.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NPEG\NPEG.csproj">
+      <Project>{567F6FBD-C5CE-4E3E-B16B-F40F1D367E35}</Project>
+      <Name>NPEG</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.0">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Client.3.5">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1 Client Profile</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Windows.Installer.3.1">
+      <Visible>False</Visible>
+      <ProductName>Windows Installer 3.1</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/NPEG.Tests.NUnit/PEGrammarParserTests.cs
+++ b/NPEG.Tests.NUnit/PEGrammarParserTests.cs
@@ -1,0 +1,1371 @@
+﻿using System;
+using System.Reflection;
+using System.Text;
+using NUnit.Framework;
+using NPEG.Extensions;
+using NPEG.GrammarInterpreter;
+using NPEG.NonTerminals;
+using NPEG.Terminals;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class PEGrammarParserTests
+	{
+		
+
+
+		[Test]
+		public void PEGrammarParser_Space()
+		{
+			AExpression rule = OneOrMore(GetRule("mSpace"));
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+
+			var bytes = Encoding.UTF8.GetBytes(" \t         \t\t           \t");
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_NewLine()
+		{
+			AExpression rule = OneOrMore(GetRule("mNewLine"));
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			// notice only matches newlines of linux/win/mac/ 
+
+			var bytes = Encoding.UTF8.GetBytes("\n\n\r\n\r\r");
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_Comment()
+		{
+			AExpression rule = OneOrMore(GetRule("mComment"));
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var bytes = Encoding.UTF8.GetBytes(@"//this is a single line comment.");
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+
+			bytes = Encoding.UTF8.GetBytes(@"/*this is a multiline comment.*/");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+
+			bytes = Encoding.UTF8.GetBytes(@"/*
+                        this 
+                        is 
+                        a   multiline 
+                        comment.
+                    */");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_WhiteSpace()
+		{
+			AExpression rule = OneOrMore(GetRule("mWhiteSpace"));
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			// In the grammar interpreter whitespace is a composite of: 
+			// newline, comment, space rules
+			var bytes =Encoding.UTF8.GetBytes(
+					@"
+                //this is a single line comment.
+                //this is a single line comment.
+                /*
+                        this 
+                        is 
+                        a   multiline 
+                        comment.
+                    */
+                //this is a single line comment.
+                //this is a single line comment.
+                /*
+                        this 
+                        is 
+                        a   multiline 
+                        comment.
+                    */
+            ");
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_Hex()
+		{
+			AExpression rule = GetRule("mHex");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var bytes = Encoding.UTF8.GetBytes("0x012345679aaabbbcccdddeeeff");
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			bytes = Encoding.UTF8.GetBytes("x012345679aaabbbcccdddeeeff");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+
+			// expected to fail
+			bytes = Encoding.UTF8.GetBytes("x012345679ggghhhiiijjjkkklllmmmnnn");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_Binary()
+		{
+			AExpression rule = GetRule("mBinary");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var bytes = Encoding.UTF8.GetBytes("0b01000101010101010");
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			bytes = Encoding.UTF8.GetBytes("b01000101010101010");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			// expected to fail
+			bytes = Encoding.UTF8.GetBytes("0b0103234234");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_Label()
+		{
+			AExpression rule = GetRule("mLabel");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = "variaBle023_name";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == input);
+
+
+			bytes = Encoding.UTF8.GetBytes("_variaBle023_name");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			bytes = Encoding.UTF8.GetBytes("AAvariaBle023_name");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			// expected to fail
+			bytes = Encoding.UTF8.GetBytes("2invalidvarname");
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_AnyCharacter()
+		{
+			AExpression rule = GetRule("mAnyCharacter");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = ".";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == ".");
+		}
+
+		[Test]
+		public void PEGrammarParser_CharacterClass()
+		{
+			AExpression rule = GetRule("mCharacterClass");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = "[a-zA-Z0-9_-]";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			input = "[^a-zA-Z0-9_-]";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_CodePoint()
+		{
+			AExpression rule = GetRule("mCodePoint");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = @"#0b01010101";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "CodePoint");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "#0b01010101");
+
+			input = @"#2563";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "CodePoint");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "#2563");
+
+
+			input = @"#0xffff";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "CodePoint");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "#0xffff");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_DynamicBackReference()
+		{
+			AExpression rule = GetRule("mDynamicBackReference");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = @"\k< CapturedLabelVariableName >";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+
+
+			input = (@"\k<CapturedLabelVariableName>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+
+
+			input = (@"\k< CapturedLabelVariableName[\i] >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "CaseSensitive");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == @"\i");
+
+
+			input = (@"\k< CapturedLabelVariableName   [\i] >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "CaseSensitive");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == @"\i");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_FATAL()
+		{
+			//It's up to the interpreter to expand: escaped \' and \" to the correct form ' and "
+
+			AExpression rule = GetRule("mFATAL");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"FaTal< fatal message without single or double quotes >");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Fatal");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "fatal message without single or double quotes");
+
+
+			input = (@"FATAL< 'Fatal with single quotes' >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with single quotes");
+
+
+			input = (@"FATAL<'Fatal with single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with single quotes");
+
+
+			input = (@"FATAL<'Fatal\'s escaped single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"Fatal\'s escaped single quotes");
+
+
+			input = (@"FATAL< ""Fatal with double quotes"" >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with double quotes");
+
+
+			input = (@"FATAL<""Fatal with double quotes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with double quotes");
+
+
+			input = (@"FATAL<""Fatal message quoteing \""some other message\"" using escapes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"Fatal message quoteing \""some other message\"" using escapes");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_WARN()
+		{
+			//It's up to the interpreter to expand: escaped \' and \" to the correct form ' and "
+
+			AExpression rule = GetRule("mWARN");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"WarN< warning message without single or double quotes >");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Warn");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning message without single or double quotes");
+
+
+			input = (@"WARN< 'warning with single quotes' >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with single quotes");
+
+
+			input = (@"WARN<'warning with single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with single quotes");
+
+
+			input = (@"WARN<'warning\'s escaped single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"warning\'s escaped single quotes");
+
+
+			input = (@"WARN< ""warning with double quotes"" >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with double quotes");
+
+
+			input = (@"WARN<""warning with double quotes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with double quotes");
+
+
+			input = (@"WARN<""warning message quoteing \""some other message\"" using escapes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) ==
+			              @"warning message quoteing \""some other message\"" using escapes");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_Literal()
+		{
+			AExpression rule = GetRule("mLiteral");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"'this is some captured text'");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Literal");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "MatchText");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "this is some captured text");
+
+
+			input = (@"""this is double quoted captured text""");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Literal");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "MatchText");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "this is double quoted captured text");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_CapturingGroup()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"(?<CapturedItemName> . )");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+
+			Assert.IsTrue(node.Children[0].Token.Name == "CapturingGroup");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedItemName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "AnyCharacter");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_TerminalReference()
+		{
+			AExpression rule = GetRule("mTerminalReference");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"(?<CapturedItemName>)");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "TerminalReference");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedItemName");
+
+
+			input = (@"(?< CapturedItemName >     )");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "TerminalReference");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedItemName");
+
+
+			input = @"(?< CapturedItemName
+                                                 \rsc 
+                                                 \rn
+                                              >     )";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "TerminalReference");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedItemName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "OptionalFlags");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.Name == "ReplaceBySingleChild");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == @"\rsc");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.Name == "ReplacementNode");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.ValueAsString(iterator) == @"\rn");
+
+
+			input =
+					@"(?< CapturedItemName 
+                                                 // some comment
+                                                 \rn // some comment
+                                                 \rsc  // some comment
+                                              >     )";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "TerminalReference");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedItemName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "OptionalFlags");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.Name == "ReplacementNode");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == @"\rn");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.Name == "ReplaceBySingleChild");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.ValueAsString(iterator) == @"\rsc");
+
+
+			input = (@"(?<CapturedItemName\rsc\rn>)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "TerminalReference");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedItemName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "OptionalFlags");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.Name == "ReplaceBySingleChild");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == @"\rsc");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.Name == "ReplacementNode");
+			Assert.IsTrue(node.Children[0].Children[1].Children[1].Token.ValueAsString(iterator) == @"\rn");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Sequence()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@". . .");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[2].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[2].Token.ValueAsString(iterator) == ".");
+
+
+			input = @". // capture first character
+                                            . // capture second character
+                                            . // capture third character
+                                           ";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[2].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[2].Token.ValueAsString(iterator) == ".");
+
+
+			input = (@"...");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[2].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[2].Token.ValueAsString(iterator) == ".");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Sequence_DoReplaceBySingleChildNode()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@".");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == ".");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_PriorityChoice()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			// no whitespace
+			var input = (@"./.");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "PrioritizedChoice");
+			Assert.IsTrue(node.Children[0].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == ".");
+
+			// whitespace
+			input = (@". / .");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "PrioritizedChoice");
+			Assert.IsTrue(node.Children[0].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == ".");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Multiple_PriorityChoiceAndSequence()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			// no whitespace
+			var input = (@".../../.../../...");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "PrioritizedChoice");
+			Assert.IsTrue(node.Children[0].Children.Count == 5);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[1].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[2].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[2].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[3].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[3].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[4].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[4].Children.Count == 3);
+
+
+			// with whitespace
+			input =
+					@"... 
+                                            / .. 
+                                            /
+                                            ... 
+                                            /
+                                            .. 
+                                            / 
+                                            ... 
+                                           ";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "PrioritizedChoice");
+			Assert.IsTrue(node.Children[0].Children.Count == 5);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[1].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[2].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[2].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[3].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[3].Children.Count == 2);
+			Assert.IsTrue(node.Children[0].Children[4].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children[4].Children.Count == 3);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Terminal_AnyCharacter()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (". . .");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == ".");
+			Assert.IsTrue(node.Children[0].Children[2].Token.ValueAsString(iterator) == ".");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Terminal_CharacterClass()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = ("[a-zA-Z0-9_-]");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			input = ("[^a-zA-Z0-9_-]");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Terminal_CodePoint()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"#0b01010101");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "CodePoint");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "#0b01010101");
+
+			input = (@"#2563");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "CodePoint");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "#2563");
+
+
+			input = (@"#0xffff");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "CodePoint");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "#0xffff");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Terminal_DynamicBackReference()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"\k< CapturedLabelVariableName >");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+
+
+			input = (@"\k<CapturedLabelVariableName>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+
+
+			input = (@"\k< CapturedLabelVariableName[\i] >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "CaseSensitive");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == @"\i");
+
+
+			input = (@"\k< CapturedLabelVariableName   [\i] >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "CapturedLabelVariableName");
+			Assert.IsTrue(node.Children[0].Children[1].Token.Name == "CaseSensitive");
+			Assert.IsTrue(node.Children[0].Children[1].Token.ValueAsString(iterator) == @"\i");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_FATAL()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"FaTal< fatal message without single or double quotes >");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Fatal");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "fatal message without single or double quotes");
+
+
+			input = (@"FATAL< 'Fatal with single quotes' >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with single quotes");
+
+
+			input = (@"FATAL<'Fatal with single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with single quotes");
+
+
+			input = (@"FATAL<'Fatal\'s escaped single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"Fatal\'s escaped single quotes");
+
+
+			input = (@"FATAL< ""Fatal with double quotes"" >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with double quotes");
+
+
+			input = (@"FATAL<""Fatal with double quotes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "Fatal with double quotes");
+
+
+			input = (@"FATAL<""Fatal message quoteing \""some other message\"" using escapes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"Fatal message quoteing \""some other message\"" using escapes");
+		}
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_Literal()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"'this is some captured text'");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Literal");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "MatchText");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "this is some captured text");
+
+
+			input = (@"""this is double quoted captured text""");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Literal");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "MatchText");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "this is double quoted captured text");
+		}
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_RecursionCall()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = ("variaBle023_name _variaBle023_name AAvariaBle023_name");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Sequence");
+			Assert.IsTrue(node.Children[0].Children.Count == 3);
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "RecursionCall");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "Label");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.ValueAsString(iterator) == "variaBle023_name");
+			Assert.IsTrue(node.Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "_variaBle023_name");
+			Assert.IsTrue(node.Children[0].Children[2].Children[0].Token.ValueAsString(iterator) == "AAvariaBle023_name");
+		}
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_WARN()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+			var input = (@"WarN< warning message without single or double quotes >");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Token.Name == "Warn");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning message without single or double quotes");
+
+
+			input = (@"WARN< 'warning with single quotes' >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with single quotes");
+
+
+			input = (@"WARN<'warning with single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with single quotes");
+
+
+			input = (@"WARN<'warning\'s escaped single quotes'>");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"warning\'s escaped single quotes");
+
+
+			input = (@"WARN< ""warning with double quotes"" >");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with double quotes");
+
+
+			input = (@"WARN<""warning with double quotes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == "warning with double quotes");
+
+
+			input = (@"WARN<""warning message quoteing \""some other message\"" using escapes"">");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "Message");
+			Assert.IsTrue(node.Children[0].Children[0].Token.ValueAsString(iterator) == @"warning message quoteing \""some other message\"" using escapes");
+		}
+
+
+		[Test]
+		public void PEGrammarParser_ExpressionRoot_LimitingRepetition()
+		{
+			AExpression rule = GetRule("mExpressionRoot");
+			AExpression root = WrapInCapturedGroup("Test", RequireEndOfInput(rule));
+
+
+			var input = (@".{55,77}");
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "BETWEEN");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.Name == "Min");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "55");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[1].Token.Name == "Max");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[1].Token.ValueAsString(iterator) == "77");
+
+
+			input = (@".{ 55 , 77 }");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "BETWEEN");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.Name == "Min");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "55");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[1].Token.Name == "Max");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[1].Token.ValueAsString(iterator) == "77");
+
+
+			input = (@".{ , 77 }");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "ATMOST");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.Name == "Max");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "77");
+
+
+			input = (@".{,77}");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "ATMOST");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children.Count == 1);
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.Name == "Max");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "77");
+
+
+			input = (@".{ 55 ,   }");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "ATLEAST");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.Name == "Min");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "55");
+
+
+			input = (@".{55,}");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "ATLEAST");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.Name == "Min");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Children[0].Token.ValueAsString(iterator) == "55");
+
+
+			input = (@".{ 95687 }");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "EXACT");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.ValueAsString(iterator) == "95687");
+
+
+			input = (@".{95687}");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Test");
+			Assert.IsTrue(node.Children[0].Token.Name == "Suffix");
+			Assert.IsTrue(node.Children[0].Children[0].Token.Name == "LimitingRepetition");
+			Assert.IsTrue(node.Children[0].Children[0].Children[0].Token.Name == "AnyCharacter");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.Name == "EXACT");
+			Assert.IsTrue(node.Children[0].Children[0].Children[1].Token.ValueAsString(iterator) == "95687");
+		}
+
+
+		private AExpression GetRule(String name)
+		{
+			Type t = typeof (PEGrammar);
+			return t.GetMethod(name, BindingFlags.Static | BindingFlags.NonPublic).Invoke(t, new Object[] {}) as AExpression;
+		}
+
+		private AExpression OneOrMore(AExpression expression)
+		{
+			return new OneOrMore(expression);
+		}
+
+		private AExpression RequireEndOfInput(AExpression expression)
+		{
+			return new Sequence(expression, new NotPredicate(new AnyCharacter()));
+		}
+
+		private AExpression WrapInCapturedGroup(String groupname, AExpression expression)
+		{
+			return new CapturingGroup(groupname, expression);
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/PracticalExampleTests.cs
+++ b/NPEG.Tests.NUnit/PracticalExampleTests.cs
@@ -1,0 +1,348 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using NPEG.Extensions;
+using NPEG.NonTerminals;
+using NPEG.Terminals;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class PracticalExampleTests
+	{
+		
+
+
+		[Test]
+		public void PracticalExample_MathematicalFormula()
+		{
+			#region Composite
+
+			var VALUE = new PrioritizedChoice(
+				new CapturingGroup("VALUE",
+				                   new OneOrMore(new CharacterClass {ClassExpression = "[0-9]"})
+					)
+				,
+				new Sequence(
+					new Literal {MatchText = "("},
+					new RecursionCall("ParethesisFunction")
+					)
+					.Sequence(new Literal {MatchText = ")"})
+				);
+
+			var PRODUCT = new Sequence(
+				VALUE,
+				new Sequence(
+					new CapturingGroup("SYMBOL",
+					                   new PrioritizedChoice(
+					                   	new Literal {MatchText = "*"},
+					                   	new Literal {MatchText = "/"}
+					                   	)
+						),
+					VALUE
+					).Star()
+				);
+
+			var SUM = new Sequence(
+				PRODUCT,
+				new Sequence(
+					new CapturingGroup("SYMBOL",
+					                   new PrioritizedChoice(
+					                   	new Literal {MatchText = "+"},
+					                   	new Literal {MatchText = "-"}
+					                   	)
+						),
+					PRODUCT
+					).Star()
+				);
+
+			AExpression EXPRESSION = new RecursionCreate("ParethesisFunction", new CapturingGroup("EXPRESSION", SUM));
+
+			#endregion
+
+			var input = "((((12/3)+5-2*(81/9))+1))";
+			var bytes = Encoding.UTF8.GetBytes(input);
+
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			EXPRESSION.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+
+
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+		}
+
+
+		[Test]
+		public void PracticalExample_BooleanAlgebra()
+		{
+			#region Composite
+
+			//AND: */AND
+			AExpression AND = new PrioritizedChoice(new Literal {MatchText = "*"}, new Literal {MatchText = "AND"});
+			//NAND: ~*/NAND
+			AExpression NAND = new PrioritizedChoice(new Literal {MatchText = "~*"}, new Literal {MatchText = "NAND"});
+
+
+			//OR: +/OR
+			AExpression OR = new PrioritizedChoice(new Literal {MatchText = "+"}, new Literal {MatchText = "OR"});
+			//NOR: ~+/NOR
+			AExpression NOR = new PrioritizedChoice(new Literal {MatchText = "~+"}, new Literal {MatchText = "NOR"});
+
+
+			//XOR: ^/XOR
+			AExpression XOR = new PrioritizedChoice(new Literal {MatchText = "^"}, new Literal {MatchText = "XOR"});
+			//XNOR: ~^/XNOR
+			AExpression XNOR = new PrioritizedChoice(new Literal {MatchText = "~^"}, new Literal {MatchText = "XNOR"});
+
+
+			AExpression GATE = new CapturingGroup("GATE", new PrioritizedChoice(AND, NAND).Or(OR).Or(NOR).Or(XOR).Or(XNOR));
+
+
+			// Variable: "[a-zA-Z0-9]+"  / '[a-zA-Z0-9]+' / [a-zA-Z]  
+			AExpression VARIABLE = new PrioritizedChoice(
+				new Sequence(
+					new Literal {MatchText = "\""},
+					new CapturingGroup("VARIABLE", new OneOrMore(new CharacterClass {ClassExpression = "[a-zA-Z0-9]"}))
+					).Sequence(new Literal {MatchText = "\""}),
+				new Sequence(
+					new Literal {MatchText = "'"},
+					new CapturingGroup("VARIABLE", new OneOrMore(new CharacterClass {ClassExpression = "[a-zA-Z0-9]"}))
+					).Sequence(new Literal {MatchText = "'"})
+				).Or(
+					new CapturingGroup("VARIABLE", new CharacterClass {ClassExpression = "[a-zA-Z]"})
+				);
+
+			// Variable: Variable / !Variable
+			VARIABLE = new PrioritizedChoice(
+				VARIABLE
+				,
+				new CapturingGroup("INVERTOR",
+				                   new Sequence(
+				                   	new Literal {MatchText = "!"},
+				                   	VARIABLE
+				                   	)
+					)
+				);
+
+
+			// Variable: Variable / Expression / !Expression
+			VARIABLE = new PrioritizedChoice(
+				VARIABLE
+				,
+				new Sequence(
+					new Literal {MatchText = "("},
+					new RecursionCall("RECURSIONEXPRESSION")
+					).Sequence(new Literal {MatchText = ")"})
+				).Or(
+					new CapturingGroup("INVERTOR",
+					                   new Sequence(
+					                   	new Literal {MatchText = "!"}
+					                   	,
+					                   	new Sequence(
+					                   		new Literal {MatchText = "("},
+					                   		new RecursionCall("RECURSIONEXPRESSION")
+					                   		).Sequence(new Literal {MatchText = ")"})
+					                   	)
+						)
+				);
+
+
+			AExpression Root = new CapturingGroup("BOOLEANEQUATION",
+			                                      new Sequence(
+			                                      	new RecursionCreate("RECURSIONEXPRESSION",
+			                                      	                    //Expression: Variable ((AND|NAND|OR|NOR|XOR|XNOR) Variable)* 
+			                                      	                    new Sequence(VARIABLE, new Sequence(GATE, VARIABLE).Star())
+			                                      		)
+			                                      	,
+			                                      	// ensure reaches end of file
+			                                      	new NotPredicate(new AnyCharacter())
+			                                      	)
+				);
+
+			#endregion
+
+			// single variable
+			var input = "A*!B+!A*B";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "BOOLEANEQUATION");
+			Assert.IsTrue(node.Children[0].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "A");
+			Assert.IsTrue(node.Children[1].Token.Name == "GATE");
+			Assert.IsTrue(node.Children[1].Token.ValueAsString(iterator) == "*");
+			Assert.IsTrue(node.Children[2].Token.Name == "INVERTOR");
+			Assert.IsTrue(node.Children[2].Children[0].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[2].Children[0].Token.ValueAsString(iterator) == "B");
+			Assert.IsTrue(node.Children[3].Token.Name == "GATE");
+			Assert.IsTrue(node.Children[4].Token.Name == "INVERTOR");
+			Assert.IsTrue(node.Children[4].Children[0].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[4].Children[0].Token.ValueAsString(iterator) == "A");
+			Assert.IsTrue(node.Children[5].Token.Name == "GATE");
+			Assert.IsTrue(node.Children[6].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[6].Token.ValueAsString(iterator) == "B");
+
+			// quoted variable
+			input = "'aA'*!'bB'+!'aA'*'bB'";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "BOOLEANEQUATION");
+			Assert.IsTrue(node.Children[0].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "aA");
+			Assert.IsTrue(node.Children[1].Token.Name == "GATE");
+			Assert.IsTrue(node.Children[1].Token.ValueAsString(iterator) == "*");
+			Assert.IsTrue(node.Children[2].Token.Name == "INVERTOR");
+			Assert.IsTrue(node.Children[2].Children[0].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[2].Children[0].Token.ValueAsString(iterator) == "bB");
+			Assert.IsTrue(node.Children[3].Token.Name == "GATE");
+			Assert.IsTrue(node.Children[4].Token.Name == "INVERTOR");
+			Assert.IsTrue(node.Children[4].Children[0].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[4].Children[0].Token.ValueAsString(iterator) == "aA");
+			Assert.IsTrue(node.Children[5].Token.Name == "GATE");
+			Assert.IsTrue(node.Children[6].Token.Name == "VARIABLE");
+			Assert.IsTrue(node.Children[6].Token.ValueAsString(iterator) == "bB");
+
+
+			// expression + gate + variable .star()
+			input = "A*!B*C+!A*B*C";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			// parethesis
+			input = "((A)*(!B)+(!A)*(B))";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = "((A)*!(B)+!(A)*(B))";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = "((A)*(!(B))+(!(A))*(B))";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(!X*Y*!Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(!X*Y*!Z)+(!X*Y*Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(X*Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning             Assert.IsTrue(node.Token.Value == input);
+
+			input = ("(!X*Y*!Z)+(!X*Y*Z)+(X*Z)");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+
+			input = ("((((!X*Y*Z)+(!X*Y*!Z)+(X*Z))))");
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Root.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+#warning            Assert.IsTrue(node.Token.Value == input);
+		}
+
+
+		[Test]
+		public void PracticalExample_PhoneNumber()
+		{
+			#region terminals
+
+			AExpression Digits = new CharacterClass {ClassExpression = "[0-9]"};
+			AExpression Hyphen = new Literal {MatchText = "-"};
+
+			#endregion
+
+			#region nonterminals
+
+			AExpression ThreeDigitCode = new CapturingGroup("ThreeDigitCode", new Sequence(Digits, Digits).Sequence(Digits));
+
+			AExpression FourDigitCode = new CapturingGroup("FourDigitCode",
+			                                               new Sequence(Digits, Digits).Sequence(Digits).Sequence(Digits));
+
+			AExpression PhoneNumber = new CapturingGroup("PhoneNumber",
+			                                             new Sequence(ThreeDigitCode, Hyphen)
+			                                             	.Sequence(ThreeDigitCode)
+			                                             	.Sequence(Hyphen)
+			                                             	.Sequence(FourDigitCode)
+				);
+
+			#endregion
+
+			String input = "123-456-7890";
+
+
+			// Test Manual Composite
+
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			PhoneNumber.Accept(visitor);
+
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "PhoneNumber");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == "123-456-7890");
+			Assert.IsTrue(node.Children[0].Token.Name == "ThreeDigitCode");
+			Assert.IsTrue(node.Children[0].Token.ValueAsString(iterator) == "123");
+			Assert.IsTrue(node.Children[1].Token.Name == "ThreeDigitCode");
+			Assert.IsTrue(node.Children[1].Token.ValueAsString(iterator) == "456");
+			Assert.IsTrue(node.Children[2].Token.Name == "FourDigitCode");
+			Assert.IsTrue(node.Children[2].Token.ValueAsString(iterator) == "7890");
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/PredicateTests.cs
+++ b/NPEG.Tests.NUnit/PredicateTests.cs
@@ -1,0 +1,63 @@
+﻿#region License
+
+/* **********************************************************************************
+ * Copyright (c) Leblanc Meneses
+ * This source code is subject to terms and conditions of the MIT License
+ * for NPEG. A copy of the license can be found in the License.txt file
+ * at the root of this distribution. 
+ * By using this source code in any fashion, you are agreeing to be bound by the terms of the 
+ * MIT License.
+ * You must not remove this notice from this software.
+ * **********************************************************************************/
+
+#endregion
+
+using System.Text;
+using NUnit.Framework;
+using NPEG.NonTerminals;
+using NPEG.Terminals;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class PredicateTests
+	{
+		
+
+		[Test]
+		public void NonTerminal_Predicate_And()
+		{
+			// predicates should not adjust the 
+			// iterator once the expression is evaluated.
+			AExpression Digit = new CharacterClass {ClassExpression = "[0-9]"};
+
+			// regex expression: \d+
+			var input = Encoding.UTF8.GetBytes("01234567890123456789");
+			var iterator = new ByteInputIterator(input);
+			AExpression andPredicate = new OneOrMore(Digit).And();
+			var visitor = new NpegParserVisitor(iterator);
+			andPredicate.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			Assert.IsTrue(iterator.Index == 0);
+		}
+
+
+		[Test]
+		public void NonTerminal_Predicate_Or()
+		{
+			// predicates should not adjust the 
+			// iterator once the expression is evaluated.
+			AExpression Digit = new CharacterClass {ClassExpression = "[0-9]"};
+
+			// equivalent to: regex '^' '$'
+			// regex expression: ^\d+$
+			var bytes = Encoding.UTF8.GetBytes("0123456abcdefg");
+			var iterator = new ByteInputIterator(bytes);
+			AExpression notPredicate = new OneOrMore(Digit).And().Sequence(new NotPredicate(new AnyCharacter()));
+			var visitor = new NpegParserVisitor(iterator);
+			notPredicate.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch); // should fail
+			Assert.IsTrue(iterator.Index == 0);
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/Properties/AssemblyInfo.cs
+++ b/NPEG.Tests.NUnit/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+
+[assembly: AssemblyTitle("TestProject1")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyCulture("")]
+
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+
+[assembly: Guid("6c3aa6d5-c775-46c9-816e-bf19a3542fa9")]

--- a/NPEG.Tests.NUnit/StreamInputIteratorTests.cs
+++ b/NPEG.Tests.NUnit/StreamInputIteratorTests.cs
@@ -1,0 +1,118 @@
+﻿#region License
+
+/* **********************************************************************************
+ * Copyright (c) Leblanc Meneses
+ * This source code is subject to terms and conditions of the MIT License
+ * for NPEG. A copy of the license can be found in the License.txt file
+ * at the root of this distribution. 
+ * By using this source code in any fashion, you are agreeing to be bound by the terms of the 
+ * MIT License.
+ * You must not remove this notice from this software.
+ * **********************************************************************************/
+
+#endregion
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using NPEG.ApplicationExceptions;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class StreamInputIteratorTests
+	{
+		
+
+
+		[Test]
+		public void Iterator_Initialization()
+		{
+			string value = "01234567890123456789";
+			byte[] bytes = Encoding.ASCII.GetBytes(value);
+			var memoryStream = new MemoryStream();
+			memoryStream.Write(bytes, 0, bytes.Length);
+			var input = new StreamInputIterator(memoryStream);
+
+			// tests that iterator begins at zero based index
+			Assert.IsTrue(input.Index == 0);
+			Assert.IsTrue(input.Length == 20);
+			Assert.IsTrue(input.Current() == '0');
+			Assert.IsTrue(input.Next() == '1');
+			Assert.IsTrue(input.Previous() == '0');
+			Assert.IsTrue(Encoding.ASCII.GetBytes(value).SequenceEqual(input.Text(0, 19)),
+			              "Text unable to return complete input.");
+		}
+
+		[Test]
+		public void Iterator_GetText_Limit()
+		{
+			string value = "01234567890123456789";
+			byte[] bytes = Encoding.ASCII.GetBytes(value);
+			var memoryStream = new MemoryStream();
+			memoryStream.Write(bytes, 0, bytes.Length);
+			var input = new StreamInputIterator(memoryStream);
+			Assert.IsTrue(Encoding.ASCII.GetBytes("0").SequenceEqual(input.Text(0, 0)), "Text unable to return first character.");
+			Assert.IsTrue(Encoding.ASCII.GetBytes("9").SequenceEqual(input.Text(19, 19)), "Text unable to return last character.");
+			Assert.IsTrue(Encoding.ASCII.GetBytes("01").SequenceEqual(input.Text(0, 1)),
+			              "Text unable to return specified start and end characters inclusive.");
+
+			try
+			{
+				input.Text(19, 0);
+				Assert.Fail("Start must be <= End");
+			}
+			catch (IteratorUsageException e)
+			{
+			}
+		}
+
+		[Test]
+		public void Iterator_OutofRange()
+		{
+			var memoryStream = new MemoryStream();
+			var input = new StreamInputIterator(memoryStream);
+			Assert.IsTrue(input.Index == 0);
+			Assert.IsTrue(input.Length == 0);
+			Assert.IsTrue(input.Current() == -1);
+			Assert.IsTrue(input.Index == 0);
+			Assert.IsTrue(input.Next() == -1);
+			Assert.IsTrue(input.Index == 0);
+			Assert.IsTrue(input.Previous() == -1);
+			Assert.IsTrue(input.Index == 0);
+		}
+
+		[Test]
+		public void Iterator_Index()
+		{
+			string value = "01234567890123456789";
+			byte[] bytes = Encoding.ASCII.GetBytes(value);
+			var memoryStream = new MemoryStream();
+			memoryStream.Write(bytes, 0, bytes.Length);
+			var input = new StreamInputIterator(memoryStream);
+			Assert.IsTrue(input.Index == 0);
+			Assert.IsTrue(input.Length == value.Length);
+
+			for (int i = 0; i < value.Length; i++)
+			{
+				Assert.IsTrue(input.Index == i);
+				Assert.IsTrue(input.Current() == value[i]);
+				if (i < value.Length - 1)
+				{
+					Assert.IsTrue(input.Next() == value[i + 1]);
+				}
+			}
+
+			for (int i = value.Length - 1; i >= 0; i--)
+			{
+				Assert.IsTrue(input.Index == i);
+				Assert.IsTrue(input.Current() == value[i]);
+				if (i > 0)
+				{
+					Assert.IsTrue(input.Previous() == value[i - 1]);
+				}
+			}
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/TerminalNodes.cs
+++ b/NPEG.Tests.NUnit/TerminalNodes.cs
@@ -1,0 +1,536 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using NPEG.Extensions;
+using NPEG.NonTerminals;
+using NPEG.Terminals;
+
+namespace NPEG.Tests
+{
+	[TestFixture]
+	public class TerminalNodes
+	{
+		
+
+		[Test]
+		public void Terminal_Any()
+		{
+			var input = "ijk";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			AExpression any = new Sequence(new AnyCharacter(), new AnyCharacter());
+			var visitor = new NpegParserVisitor(iterator);
+			any.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			Assert.IsTrue(iterator.Index == 2,
+			              "Expected two characters to be consumed and Iterator updated by 2.  0, 1 .. points to 2");
+
+			input = "ij";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			any.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			Assert.IsTrue(iterator.Index == 2,
+			              "Expected two characters to be consumed and Iterator updated by 2.  0, 1 .. points to 2");
+
+			input = "";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			any = new AnyCharacter();
+			visitor = new NpegParserVisitor(iterator);
+			any.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+			Assert.IsTrue(iterator.Index == 0, "Expected no characters to be consumed and index stay at zero.");
+
+			var number = new Sequence(
+				new OneOrMore(new CharacterClass {ClassExpression = "[0-9]"}),
+				new NotPredicate(
+					new AnyCharacter()
+					)
+				);
+			input = "012345.";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			number.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void Terminal_CharacterClass()
+		{
+			AExpression Digit = new CharacterClass {ClassExpression = "[0-9]"};
+
+			var input = "0";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			Digit.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+
+			input = "0123456789";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			new OneOrMore(Digit).Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+		[Test]
+		public void Terminal_Literal()
+		{
+			var Mixed = new Literal {MatchText = "Hello World"};
+
+			var input = "hello world";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			Mixed.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+
+			// Not case sensitve
+			Mixed.IsCaseSensitive = false;
+
+			input = "hello world";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Mixed.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void Terminal_CodePoint_Hexadecimal()
+		{
+			Assert.IsTrue((Byte) 'a' == 97);
+			Assert.IsTrue((Byte) 'a' == 0x61);
+			var input = "a";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			var Hexadecimal = new CapturingGroup("Hexadecimal",
+			    new CodePoint {Match = "#x61"}
+			);
+			Hexadecimal.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Hexadecimal");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == "a");
+
+
+			// Byte boundary tests
+			input = "\na";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Hexadecimal = new CapturingGroup("Hexadecimal",
+			    new CodePoint {Match = "#xA61"}
+			);
+			Hexadecimal.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch, "During incomplete byte boundaries 0 is expected to prefix input;  This would shift input to the right by 4 bits.  In this case it complete codepoint should be 0A = \n and letter a.");
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Hexadecimal");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == "\na");
+
+			input = "\0a";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Hexadecimal = new CapturingGroup("Hexadecimal",
+			                                 new CodePoint {Match = "#x061"}
+				);
+			Hexadecimal.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch, "During incomplete byte boundaries 0 is expected to prefix input;  This would shift input to the right by 4 bits.  In this case it complete codepoint should be 00 = \0 and letter a.");
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Hexadecimal");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == "\0a");
+
+
+			// Don't care tests
+			bytes = new byte[] {0x11, 0x01, 0x71, 0x03, 0x00};
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			Hexadecimal = new CapturingGroup("Hexadecimal",
+			                                 new OneOrMore(new CodePoint {Match = "#xX1"}) // #bXXXX0001
+			);
+			Hexadecimal.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.Name == "Hexadecimal");
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == Encoding.ASCII.GetString(new byte[] {0x11, 0x01, 0x71}));
+
+
+			iterator = new ByteInputIterator(new byte[] { 0x10 });
+			visitor = new NpegParserVisitor(iterator);
+			Hexadecimal = new CapturingGroup("Hexadecimal",
+			                                 new CodePoint {Match = "#xX1"}
+				);
+			Hexadecimal.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+
+
+			// cannot consume character test
+			input = string.Empty;
+			iterator = new ByteInputIterator(Encoding.UTF8.GetBytes(input));
+			visitor = new NpegParserVisitor(iterator);
+			Hexadecimal = new CapturingGroup("Hexadecimal",
+			                                 new CodePoint {Match = "#xX1"}
+				);
+			Hexadecimal.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void Terminal_CodePoint_Binary()
+		{
+			Assert.IsTrue((Byte) 'a' == 97);
+			Assert.IsTrue((Byte) 'a' == 0x61);
+
+			var input = "a";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			var binary = new CapturingGroup("Binary",
+			                                new CodePoint {Match = "#b1100001"}
+				);
+			binary.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode ast = visitor.AST;
+			Assert.IsTrue(ast.Token.Name == "Binary");
+			Assert.IsTrue(ast.Token.ValueAsString(iterator) == "a");
+
+
+			input = "aa";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			binary = new CapturingGroup("Binary",
+			                            new CodePoint {Match = "#b0110000101100001"}
+				);
+			binary.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			ast = visitor.AST;
+			Assert.IsTrue(ast.Token.Name == "Binary");
+			Assert.IsTrue(ast.Token.ValueAsString(iterator) == "aa");
+
+
+			// Byte boundary tests
+			input = "\0a";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			binary = new CapturingGroup("Binary",
+			                            new CodePoint {Match = "#b00001100001"}
+				);
+			binary.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch, "During incomplete byte boundaries 0 is expected to prefix input;  This would shift input to the right by 4 bits.  In this case it complete codepoint should be null and letter a.");
+			ast = visitor.AST;
+			Assert.IsTrue(ast.Token.Name == "Binary");
+			Assert.IsTrue(ast.Token.ValueAsString(iterator) == "\0a");
+
+
+			input = "\0a";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			binary = new CapturingGroup("Binary", new Sequence(new CodePoint {Match = "#b000"}, new CodePoint {Match = "#b01100001"}));
+			binary.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch,
+			              "During incomplete byte boundaries 0 is expected to prefix input;  This would shift input to the right by 4 bits.  In this case it complete codepoint should be null and letter a.");
+			ast = visitor.AST;
+			Assert.IsTrue(ast.Token.Name == "Binary");
+			Assert.IsTrue(ast.Token.ValueAsString(iterator) == "\0a");
+
+
+			// Don't care tests
+			input = Encoding.ASCII.GetString(new byte[] { 0x11, 0x01, 0x71, 0x03, 0x00 });
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			binary = new CapturingGroup("Binary",
+			         new OneOrMore(new CodePoint {Match = "#bXXXX0001"}) // #bXXXX0001
+			);
+			binary.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			ast = visitor.AST;
+			Assert.IsTrue(ast.Token.Name == "Binary");
+			Assert.IsTrue(ast.Token.ValueAsString(iterator) == Encoding.ASCII.GetString(new byte[] { 0x11, 0x01, 0x71 }));
+
+
+			input = Encoding.ASCII.GetString(new byte[] { 0x10 });
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			binary = new CapturingGroup("Binary", new CodePoint {Match = "#bXXXX0001"});
+			binary.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+
+
+			// cannot consume character test
+			input = "";
+			bytes = Encoding.UTF8.GetBytes(input);
+			iterator = new ByteInputIterator(bytes);
+			visitor = new NpegParserVisitor(iterator);
+			binary = new CapturingGroup("Binary", new CodePoint {Match = "#bXXXX0001"});
+			binary.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+		}
+
+
+		[Test]
+		public void Terminal_CodePoint_Decimal()
+		{
+			var input = "&";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+			var codepoint = new CapturingGroup("CodePoint",
+			                                   new CodePoint {Match = "#38"}
+				);
+			codepoint.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode ast = visitor.AST;
+			Assert.IsTrue(ast.Token.Name == "CodePoint");
+			Assert.IsTrue(ast.Token.ValueAsString(iterator) == "&");
+		}
+
+
+		[Test]
+		public void Terminal_LimitingRepetition()
+		{
+			// min
+			// min max
+			// max
+			// math expression using back referencing {(\k<C2> - \k<C1>)+1} - variable length protocols
+
+			AExpression Digits = new CharacterClass {ClassExpression = "[0-9]"};
+
+			#region nonterminals
+
+			var MinTrue0 = new CapturingGroup("MinTrue",
+			                                  new LimitingRepetition(Digits) {Min = 0}
+				);
+			var MinFalse = new CapturingGroup("MinFalse",
+			                                  new LimitingRepetition(Digits) {Min = 44}
+				);
+
+
+			var MinTrue5 = new CapturingGroup("MinTrue",
+			                                  new LimitingRepetition(Digits) {Min = 5}
+				);
+			var MaxTrue = new CapturingGroup("MaxTrue",
+			                                 new LimitingRepetition(Digits) {Max = 5}
+				);
+			var MinMax = new CapturingGroup("MinMax",
+			                                new LimitingRepetition(Digits) {Min = 5, Max = 6}
+				);
+
+
+			var ExceptionNoMinMax = new CapturingGroup("ExceptionNoMinMax",
+			                                           new LimitingRepetition(Digits) {}
+				);
+			var ExceptionMaxLessThanMin = new CapturingGroup("ExceptionMaxLessThanMin",
+			                                                 new LimitingRepetition(Digits) {Min = 5, Max = 0}
+				);
+
+			#endregion
+
+			String input = "1234567890";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			MinTrue0.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+
+			iterator.Index = 0;
+			visitor = new NpegParserVisitor(iterator);
+			MinFalse.Accept(visitor);
+			Assert.IsFalse(visitor.IsMatch);
+
+
+			iterator.Index = 0;
+			visitor = new NpegParserVisitor(iterator);
+			MinTrue5.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+			Assert.IsTrue(node.Token.ValueAsString(iterator) == input);
+
+
+			iterator.Index = 0;
+			visitor = new NpegParserVisitor(iterator);
+			MaxTrue.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+
+
+			iterator.Index = 0;
+			visitor = new NpegParserVisitor(iterator);
+			MinMax.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			node = visitor.AST;
+
+
+			Int32 exceptionCount = 0;
+			try
+			{
+				iterator.Index = 0;
+				visitor = new NpegParserVisitor(iterator);
+				ExceptionNoMinMax.Accept(visitor);
+				Assert.IsTrue(visitor.IsMatch);
+				node = visitor.AST;
+			}
+			catch (ArgumentException)
+			{
+				exceptionCount++;
+			}
+
+			try
+			{
+				iterator.Index = 0;
+				visitor = new NpegParserVisitor(iterator);
+				ExceptionMaxLessThanMin.Accept(visitor);
+				Assert.IsTrue(visitor.IsMatch);
+				node = visitor.AST;
+			}
+			catch (ArgumentException)
+			{
+				exceptionCount++;
+			}
+
+
+			Assert.IsTrue(exceptionCount == 2);
+		}
+
+
+		[Test]
+		public void Terminal_DynamicBackReference()
+		{
+			#region Composite
+
+			AExpression TAG = new CapturingGroup("TAG",
+			                                     new OneOrMore(
+			                                     	new CharacterClass {ClassExpression = "[a-zA-Z0-9]"}
+			                                     	)
+				);
+
+			AExpression StartTag = new CapturingGroup("START_TAG",
+			                                          new Sequence(
+			                                          	new Literal {MatchText = "<"}, TAG)
+			                                          	.Sequence(
+			                                          		new Literal {MatchText = ">"}
+			                                          	)
+				);
+
+			AExpression EndTag = new CapturingGroup("END_TAG",
+			                                        new Sequence(
+			                                        	new Literal {MatchText = "</"},
+			                                        	new DynamicBackReference
+			                                        		{
+			                                        			BackReferenceName = "TAG",
+			                                        			IsCaseSensitive = true
+			                                        		}
+			                                        	)
+			                                        	.Sequence(
+			                                        		new Literal {MatchText = ">"}
+			                                        	)
+				);
+
+
+			AExpression Body = new CapturingGroup("Body", new Sequence(new NotPredicate(EndTag), new AnyCharacter()).Star());
+
+			AExpression Expression = new CapturingGroup("Expression", new Sequence(StartTag, Body).Sequence(EndTag).Plus());
+
+			#endregion
+
+			String input = "<h1>hello</h1><h2>hello</h2>";
+			var bytes = Encoding.UTF8.GetBytes(input);
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			Expression.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode ast = visitor.AST;
+#warning write tree
+		}
+
+
+		[Test]
+		public void Terminal_DynamicBackReference_Recursive()
+		{
+			String input =
+				@"
+                    <test>
+                        test data start
+                        <test1>
+                            test1 data start
+                            <test2>
+                                text2 data start
+                                text2 data end
+                            </test2>
+                            test1 data end
+                        </test1>
+                        test data end
+                    </test>
+                ";
+
+			var TAG = new CapturingGroup("TAG",
+			                             new OneOrMore(
+			                             	new CharacterClass {ClassExpression = "[a-zA-Z0-9]"}
+			                             	)
+				);
+
+			var StartTag = new CapturingGroup("START_TAG",
+			                                  new Sequence(
+			                                  	new Literal {MatchText = "<"}, TAG)
+			                                  	.Sequence(
+			                                  		new Literal {MatchText = ">"}
+			                                  	)
+				);
+
+			var EndTag = new CapturingGroup("END_TAG",
+			                                new Sequence(
+			                                	new Literal {MatchText = "</"},
+			                                	new DynamicBackReference
+			                                		{
+			                                			BackReferenceName = "TAG",
+			                                			IsCaseSensitive = true
+			                                		}
+			                                	)
+			                                	.Sequence(
+			                                		new Literal {MatchText = ">"}
+			                                	)
+				);
+
+
+			var Body = new CapturingGroup("Body",
+			                              new PrioritizedChoice(
+			                              	new RecursionCall("MATCHXML"),
+			                              	new Sequence(new NotPredicate(EndTag), new AnyCharacter())
+			                              	).Star()
+				);
+
+			var Expression = new CapturingGroup("Expression",
+			                                    new RecursionCreate("MATCHXML",
+			                                                        new Sequence(StartTag, Body)
+			                                                        	.Sequence(EndTag)
+			                                                        	.Plus()
+			                                    	)
+				);
+
+
+			var bytes = Encoding.UTF8.GetBytes(input.Trim());
+			var iterator = new ByteInputIterator(bytes);
+			var visitor = new NpegParserVisitor(iterator);
+
+			Expression.Accept(visitor);
+			Assert.IsTrue(visitor.IsMatch);
+			AstNode node = visitor.AST;
+		}
+	}
+}

--- a/NPEG.Tests.NUnit/packages.config
+++ b/NPEG.Tests.NUnit/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
I am working on a cross-platform Mono based project and am using NPEG and needed to add NUnit tests to support some regression testing of changes that I am making.

These changes do not touch NPEG at all since it works fine under Mono but does cause the test cases to be duplicated since NUnit has different test attributes than MS Test. 
- Robert/SushiHangover
## NUnit support: Copy and modified tests to use NUnit for use under Mono
- NPEG.Mono.sln (New)
  1 -> NPEG.csproj (Link to existing project)
  2 -> NPEG.Tests.NUnit.csproj (New)
- NPEG.Test -> NPEG.Test.NUnit:
  1 -> Copy & Modified tests to use NUnit

_MSTest GUID type are not supported in MonoDevelop/Xamarin since it is tied to the VS UnitTestFramework namespace that is not available in Mono_

Note: These NUnit tests run fine under Visual Studio and could be linked to the original VS solution, but you would still need a solution for MonoDevelop/Xamarin that does not include the MSTest type project (GUID ID = {3AC096D0-A1C2-E12C-1390-A8335801FDAB}
